### PR TITLE
[jade]  Add license feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+services:
+  - docker
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    recipients:
+      - gm130s@gmail.com
+env:
+  matrix:
+    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="jade"   PRERELEASE=true
+    - ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="kinetic"   PRERELEASE=true
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="jade"   PRERELEASE=true  # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
+    - env: ROS_DISTRO="kinetic"   PRERELEASE=true
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - .ci_config/travis.sh
+#  - source ./travis.sh  # Enable this when you have a package-local script 

--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -317,7 +317,7 @@ class ROSPACK_DECL Rosstackage
      * @param deps Names of the depended stackages.
      * @param licenses Pairs of (package name, license(s)).
      */
-    void licenses(std::vector<std::string>& deps, std::set<std::pair<std::string, std::vector<std::string> > >& licenses);
+    void licenses(std::vector<std::string>& deps, std::set<Stackage>& licenses);
     /**
      * @brief List names and paths of all stackages.
      * @param list Pairs of (name,path) are written here.

--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -107,6 +107,7 @@ and Rosstack.
 
 #include <boost/tr1/unordered_set.hpp>
 #include <boost/tr1/unordered_map.hpp>
+#include <functional>
 #include <list>
 #include <map>
 #include <set>
@@ -317,7 +318,7 @@ class ROSPACK_DECL Rosstackage
      * @param deps Names of the depended stackages.
      * @param licenses Pairs of (package name, license(s)).
      */
-    void licenses(std::vector<std::string>& deps, std::set<Stackage>& licenses);
+    void licenses(std::vector<std::string>& deps, std::set<Stackage, std::not_equal_to<Stackage> >& license_stackages);
     /**
      * @brief List names and paths of all stackages.
      * @param list Pairs of (name,path) are written here.

--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -111,6 +111,7 @@ and Rosstack.
 #include <map>
 #include <set>
 #include <string>
+#include "tinyxml.h"
 #include <vector>
 #include "macros.h"
 
@@ -130,8 +131,39 @@ typedef enum
 } traversal_order_t;
 
 // Forward declarations
-class Stackage;
 class DirectoryCrawlRecord;
+
+class Stackage
+{
+  public:
+    // \brief name of the stackage
+    std::string name_;
+    // \brief absolute path to the stackage
+    std::string path_;
+    // \brief absolute path to the stackage manifest
+    std::string manifest_path_;
+    // \brief filename of the stackage manifest
+    std::string manifest_name_;
+    // \brief package's license with a support for multi-license.
+    std::vector<std::string> licenses_;
+    // \brief have we already loaded the manifest?
+    bool manifest_loaded_;
+    // \brief TinyXML structure, filled in during parsing
+    TiXmlDocument manifest_;
+    std::vector<Stackage*> deps_;
+    bool deps_computed_;
+    bool is_wet_package_;
+    bool is_metapackage_;
+
+    Stackage(const std::string& name,
+             const std::string& path,
+             const std::string& manifest_path,
+             const std::string& manifest_name);
+
+    void update_wet_information();
+    bool isStack() const;
+    bool isPackage() const;
+};
 
 /**
  * @brief The base class for package/stack ("stackage") crawlers.  Users of the library should

--- a/include/rospack/rospack.h
+++ b/include/rospack/rospack.h
@@ -313,6 +313,12 @@ class ROSPACK_DECL Rosstackage
                   std::string& path);
 
     /**
+     * @brief List license(s) of a stackage whose name is passed.
+     * @param deps Names of the depended stackages.
+     * @param licenses Pairs of (package name, license(s)).
+     */
+    void licenses(std::vector<std::string>& deps, std::set<std::pair<std::string, std::vector<std::string> > >& licenses);
+    /**
      * @brief List names and paths of all stackages.
      * @param list Pairs of (name,path) are written here.
      */

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -480,7 +480,7 @@ Rosstackage::contains(const std::string& name,
  * @param deps Package names that a given package depends on and are returned by `rospack` dep*` command.
  * @param licenses Set of pairs of <package name, <package license>>.
  */
-void Rosstackage::licenses(std::vector<std::string>& deps, std::set<Stackage>& licenses) {
+void Rosstackage::licenses(std::vector<std::string>& deps, std::set<Stackage, std::not_equal_to<Stackage> >& license_stackages) {
 
   const std::string& xmlelem_license = "license";
   // Iterate each package to get the license declaration(s).
@@ -495,7 +495,7 @@ void Rosstackage::licenses(std::vector<std::string>& deps, std::set<Stackage>& l
       logError("Package/stackage " + pkg_name + " is not found.");
       continue; // Is this way good enough to return this function?
     }
-    licenses.insert(*stackage);
+    license_stackages.insert(*stackage);  //--> error https://github.com/130s/rospack/pull/4#issue-235003119
   }
 }
 

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -497,22 +497,7 @@ void Rosstackage::licenses(std::vector<std::string>& deps,
       continue; // Is this way good enough to return this function?
     }
 
-    // Parsing xml file. Copied from computeDepsInternal
-    TiXmlElement* root;
-    root = get_manifest_root(stackage);
-
-    TiXmlNode *dep_node = NULL;
-    const char* license_from_dependedPkg;
-    std::vector<std::string> licenses_dependedPkg;
-    while ((dep_node = root->IterateChildren(xmlelem_license, dep_node))) // Iterate per depended pkg.
-    {
-      TiXmlElement *dep_ele = dep_node->ToElement();
-      license_from_dependedPkg = dep_ele->GetText();
-      // TODO need to obtain as many license declarations as possible per pkg
-      //      (in the case of multiple-license).
-      licenses_dependedPkg.push_back(license_from_dependedPkg);
-    }
-    licenses.insert(std::pair<std::string, std::vector<std::string> >(pkg_name.c_str(), licenses_dependedPkg));
+    licenses.insert(std::pair<std::string, std::vector<std::string> >(pkg_name.c_str(), stackage->licenses_));
   }
 }
 

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -475,6 +475,47 @@ Rosstackage::contains(const std::string& name,
   return false;
 }
 
+/**
+ * @brief Intended to be called as an option of `rospack` dep*` commands.
+ * @param deps Package names that a given package depends on and are returned by `rospack` dep*` command.
+ * @param licenses Set of pairs of <package name, <package license>>.
+ */
+void Rosstackage::licenses(std::vector<std::string>& deps,
+		std::set<std::pair<std::string, std::vector<std::string> > >& licenses) {
+
+  const std::string& xmlelem_license = "license";
+  // Iterate each package to get the license declaration(s).
+  int i_debug = 0;
+  std::vector<std::string>::const_iterator it_pkgname;
+  for (it_pkgname = deps.begin(); it_pkgname < deps.end(); ++it_pkgname)
+  {
+    std::string pkg_name = *it_pkgname;
+    Stackage* stackage = findWithRecrawl(pkg_name);
+    if (stackage == NULL)
+    {
+      logError("Package/stackage " + pkg_name + " is not found.");
+      continue; // Is this way good enough to return this function?
+    }
+
+    // Parsing xml file. Copied from computeDepsInternal
+    TiXmlElement* root;
+    root = get_manifest_root(stackage);
+
+    TiXmlNode *dep_node = NULL;
+    const char* license_from_dependedPkg;
+    std::vector<std::string> licenses_dependedPkg;
+    while ((dep_node = root->IterateChildren(xmlelem_license, dep_node))) // Iterate per depended pkg.
+    {
+      TiXmlElement *dep_ele = dep_node->ToElement();
+      license_from_dependedPkg = dep_ele->GetText();
+      // TODO need to obtain as many license declarations as possible per pkg
+      //      (in the case of multiple-license).
+      licenses_dependedPkg.push_back(license_from_dependedPkg);
+    }
+    licenses.insert(std::pair<std::string, std::vector<std::string> >(pkg_name.c_str(), licenses_dependedPkg));
+  }
+}
+
 void
 Rosstackage::list(std::set<std::pair<std::string, std::string> >& list)
 {

--- a/src/rospack.cpp
+++ b/src/rospack.cpp
@@ -480,8 +480,7 @@ Rosstackage::contains(const std::string& name,
  * @param deps Package names that a given package depends on and are returned by `rospack` dep*` command.
  * @param licenses Set of pairs of <package name, <package license>>.
  */
-void Rosstackage::licenses(std::vector<std::string>& deps,
-		std::set<std::pair<std::string, std::vector<std::string> > >& licenses) {
+void Rosstackage::licenses(std::vector<std::string>& deps, std::set<Stackage>& licenses) {
 
   const std::string& xmlelem_license = "license";
   // Iterate each package to get the license declaration(s).
@@ -496,8 +495,7 @@ void Rosstackage::licenses(std::vector<std::string>& deps,
       logError("Package/stackage " + pkg_name + " is not found.");
       continue; // Is this way good enough to return this function?
     }
-
-    licenses.insert(std::pair<std::string, std::vector<std::string> >(pkg_name.c_str(), stackage->licenses_));
+    licenses.insert(*stackage);
   }
 }
 

--- a/src/rospack_cmdline.cpp
+++ b/src/rospack_cmdline.cpp
@@ -375,22 +375,22 @@ rospack_run(int argc, char** argv, rospack::Rosstackage& rp, std::string& output
     {
     	std::vector<std::string> dep_licenses;
 
-    	// pkgnames_licenses data structure:
+    	// stackages data structure:
     	//
     	// Packages
     	// - package name
     	// - license names
-    	std::set<std::pair<std::string, std::vector<std::string> > > pkgnames_licenses;
+    	std::set<Stackage> stackages;
 
-    	rp.licenses(deps, pkgnames_licenses);
-        for(std::set<std::pair<std::string, std::vector<std::string> > >::const_iterator it = pkgnames_licenses.begin();
-            it != pkgnames_licenses.end();
-            ++it)
+    	rp.licenses(deps, stackages);
+        for(std::set<Stackage>::const_iterator it_stackage = stackages.begin();
+            it_stackage != stackages.end();
+            ++it_stackage)
         {
-          for(std::vector<std::string>::const_iterator jt = it->second.begin();
-                jt != it->second.end(); ++jt) {
-        	//output.append(std::string(it->first) + " " + std::string(it->second.) + "\n");
-            output.append(it->first + " " + jt->c_str() + "\n");
+          for(std::vector<std::string>::const_iterator it_license = it_stackage->licenses_.begin();
+              it_license != it_stackage->licenses_.end(); ++it_license) {
+            //output.append(it_license->c_str() + "\n\t " + jt->c_str() + "\n");
+            output.append(*it_license + "\n\t ");
           }
         }
     }

--- a/src/rospack_cmdline.cpp
+++ b/src/rospack_cmdline.cpp
@@ -380,7 +380,7 @@ rospack_run(int argc, char** argv, rospack::Rosstackage& rp, std::string& output
     	// Packages
     	// - package name
     	// - license names
-    	std::set<Stackage> stackages;
+    	std::set<Stackage, std::not_equal_to<Stackage> > stackages;
 
     	rp.licenses(deps, stackages);
         for(std::set<Stackage>::const_iterator it_stackage = stackages.begin();

--- a/test/test/utest.py.in
+++ b/test/test/utest.py.in
@@ -228,6 +228,7 @@ class RospackTestCase(unittest.TestCase):
         self.rospack_fail(None, "deps --length=10")
         self.rospack_fail(None, "deps --zombie-only")
         self.rospack_fail(None, "profile --deps-only")
+        self.rospack_fail(None, "profile --license")
 
     def test_ros_cache_timeout(self):
         env = os.environ.copy()
@@ -300,6 +301,7 @@ class RospackTestCase(unittest.TestCase):
 
     def test_no_package_allowed_bad(self):
         self.rospack_fail("deps", "profile")
+        self.rospack_fail("deps", "license")
         self.rospack_fail("deps", "list")
         self.rospack_fail("deps", "list-names")
         self.rospack_fail("deps", "list-duplicates")


### PR DESCRIPTION
As of now compilation fails as follows, so **do NOT merge yet**.

An updated version of https://github.com/ros/rospack/pull/56 using newer changes that have been made since it was open.

```
$ catkin b rospack --no-deps
==> Expanding alias 'b' from 'catkin b rospack --no-deps' to 'catkin build rospack --no-deps'
---------------------------------------------------------------------------------
Profile:                     default
Extending:             [env] /opt/ros/indigo
Workspace:                   /home/n130s/link/ROS/indigo_trusty/cws_rosdt
---------------------------------------------------------------------------------
Source Space:       [exists] /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src
Log Space:         [missing] /home/n130s/link/ROS/indigo_trusty/cws_rosdt/logs
Build Space:        [exists] /home/n130s/link/ROS/indigo_trusty/cws_rosdt/build
Devel Space:        [exists] /home/n130s/link/ROS/indigo_trusty/cws_rosdt/devel
Install Space:      [unused] /home/n130s/link/ROS/indigo_trusty/cws_rosdt/install
DESTDIR:            [unused] None
---------------------------------------------------------------------------------
Devel Space Layout:          merged
Install Space Layout:        None
---------------------------------------------------------------------------------
Additional CMake Args:       None
Additional Make Args:        None
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
---------------------------------------------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        None
---------------------------------------------------------------------------------
Workspace configuration appears valid.
---------------------------------------------------------------------------------
[build] Found '99' packages in 0.0 seconds.
[build] Updating package table.
Starting  >>> rospack
_________________________________________________________________________________________________________
Errors     << rospack:make /home/n130s/link/ROS/indigo_trusty/cws_rosdt/logs/rospack/build.make.000.log
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h: In instantiation of ‘bool std::less<_Tp>::operator()(const _Tp&, const _Tp&) const [with _Tp = rospack::Stackage]’:
/usr/include/c++/4.8/bits/stl_tree.h:1324:11:   required from ‘std::pair<std::_Rb_tree_node_base*, std::_Rb_tree_node_base*> std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_get_insert_unique_pos(const key_type&) [with _Key = rospack::Stackage; _Val = rospack::Stackage; _KeyOfValue = std::_Identity<rospack::Stackage>; _Compare = std::less<rospack::Stackage>; _Alloc = std::allocator<rospack::Stackage>; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::key_type = rospack::Stackage]’
/usr/include/c++/4.8/bits/stl_tree.h:1377:47:   required from ‘std::pair<std::_Rb_tree_iterator<_Val>, bool> std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_insert_unique(const _Val&) [with _Key = rospack::Stackage; _Val = rospack::Stackage; _KeyOfValue = std::_Identity<rospack::Stackage>; _Compare = std::less<rospack::Stackage>; _Alloc = std::allocator<rospack::Stackage>]’
/usr/include/c++/4.8/bits/stl_set.h:463:29:   required from ‘std::pair<typename std::_Rb_tree<_Key, _Key, std::_Identity<_Key>, _Compare, typename _Alloc::rebind<_Key>::other>::const_iterator, bool> std::set<_Key, _Compare, _Alloc>::insert(const value_type&) [with _Key = rospack::Stackage; _Compare = std::less<rospack::Stackage>; _Alloc = std::allocator<rospack::Stackage>; typename std::_Rb_tree<_Key, _Key, std::_Identity<_Key>, _Compare, typename _Alloc::rebind<_Key>::other>::const_iterator = std::_Rb_tree_const_iterator<rospack::Stackage>; std::set<_Key, _Compare, _Alloc>::value_type = rospack::Stackage]’
/home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:498:30:   required from here
/usr/include/c++/4.8/bits/stl_function.h:235:20: error: no match for ‘operator<’ (operand types are ‘const rospack::Stackage’ and ‘const rospack::Stackage’)
       { return __x < __y; }
                    ^
/usr/include/c++/4.8/bits/stl_function.h:235:20: note: candidates are:
In file included from /usr/include/c++/4.8/utility:70:0,
                 from /usr/include/boost/config/no_tr1/utility.hpp:21,
                 from /usr/include/boost/config/select_stdlib_config.hpp:37,
                 from /usr/include/boost/config.hpp:40,
                 from /usr/include/boost/tr1/detail/config.hpp:164,
                 from /usr/include/boost/tr1/unordered_set.hpp:8,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_pair.h:220:5: note: template<class _T1, class _T2> bool std::operator<(const std::pair<_T1, _T2>&, const std::pair<_T1, _T2>&)
     operator<(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
     ^
/usr/include/c++/4.8/bits/stl_pair.h:220:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::pair<_T1, _T2>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/bits/stl_algobase.h:67:0,
                 from /usr/include/c++/4.8/memory:62,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:14,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_iterator.h:297:5: note: template<class _Iterator> bool std::operator<(const std::reverse_iterator<_Iterator>&, const std::reverse_iterator<_Iterator>&)
     operator<(const reverse_iterator<_Iterator>& __x,
     ^
/usr/include/c++/4.8/bits/stl_iterator.h:297:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::reverse_iterator<_Iterator>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/bits/stl_algobase.h:67:0,
                 from /usr/include/c++/4.8/memory:62,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:14,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_iterator.h:347:5: note: template<class _IteratorL, class _IteratorR> bool std::operator<(const std::reverse_iterator<_Iterator>&, const std::reverse_iterator<_IteratorR>&)
     operator<(const reverse_iterator<_IteratorL>& __x,
     ^
/usr/include/c++/4.8/bits/stl_iterator.h:347:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::reverse_iterator<_Iterator>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/string:52:0,
                 from /usr/include/c++/4.8/bits/locale_classes.h:40,
                 from /usr/include/c++/4.8/bits/ios_base.h:41,
                 from /usr/include/c++/4.8/ios:42,
                 from /usr/include/c++/4.8/ostream:38,
                 from /usr/include/c++/4.8/iterator:64,
                 from /usr/include/boost/detail/iterator.hpp:54,
                 from /usr/include/boost/iterator/iterator_categories.hpp:10,
                 from /usr/include/boost/unordered/detail/util.hpp:16,
                 from /usr/include/boost/unordered/detail/buckets.hpp:14,
                 from /usr/include/boost/unordered/detail/table.hpp:10,
                 from /usr/include/boost/unordered/detail/equivalent.hpp:14,
                 from /usr/include/boost/unordered/unordered_set.hpp:17,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/basic_string.h:2569:5: note: template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const std::basic_string<_CharT, _Traits, _Alloc>&, const std::basic_string<_CharT, _Traits, _Alloc>&)
     operator<(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
     ^
/usr/include/c++/4.8/bits/basic_string.h:2569:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::basic_string<_CharT, _Traits, _Alloc>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/string:52:0,
                 from /usr/include/c++/4.8/bits/locale_classes.h:40,
                 from /usr/include/c++/4.8/bits/ios_base.h:41,
                 from /usr/include/c++/4.8/ios:42,
                 from /usr/include/c++/4.8/ostream:38,
                 from /usr/include/c++/4.8/iterator:64,
                 from /usr/include/boost/detail/iterator.hpp:54,
                 from /usr/include/boost/iterator/iterator_categories.hpp:10,
                 from /usr/include/boost/unordered/detail/util.hpp:16,
                 from /usr/include/boost/unordered/detail/buckets.hpp:14,
                 from /usr/include/boost/unordered/detail/table.hpp:10,
                 from /usr/include/boost/unordered/detail/equivalent.hpp:14,
                 from /usr/include/boost/unordered/unordered_set.hpp:17,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/basic_string.h:2581:5: note: template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const std::basic_string<_CharT, _Traits, _Alloc>&, const _CharT*)
     operator<(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
     ^
/usr/include/c++/4.8/bits/basic_string.h:2581:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::basic_string<_CharT, _Traits, _Alloc>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/string:52:0,
                 from /usr/include/c++/4.8/bits/locale_classes.h:40,
                 from /usr/include/c++/4.8/bits/ios_base.h:41,
                 from /usr/include/c++/4.8/ios:42,
                 from /usr/include/c++/4.8/ostream:38,
                 from /usr/include/c++/4.8/iterator:64,
                 from /usr/include/boost/detail/iterator.hpp:54,
                 from /usr/include/boost/iterator/iterator_categories.hpp:10,
                 from /usr/include/boost/unordered/detail/util.hpp:16,
                 from /usr/include/boost/unordered/detail/buckets.hpp:14,
                 from /usr/include/boost/unordered/detail/table.hpp:10,
                 from /usr/include/boost/unordered/detail/equivalent.hpp:14,
                 from /usr/include/boost/unordered/unordered_set.hpp:17,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/basic_string.h:2593:5: note: template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const _CharT*, const std::basic_string<_CharT, _Traits, _Alloc>&)
     operator<(const _CharT* __lhs,
     ^
/usr/include/c++/4.8/bits/basic_string.h:2593:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   mismatched types ‘const _CharT*’ and ‘rospack::Stackage’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/deque:64:0,
                 from /usr/include/boost/detail/container_fwd.hpp:91,
                 from /usr/include/boost/functional/hash/extensions.hpp:17,
                 from /usr/include/boost/functional/hash/hash.hpp:529,
                 from /usr/include/boost/functional/hash.hpp:6,
                 from /usr/include/boost/unordered/unordered_set.hpp:20,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_deque.h:273:5: note: template<class _Tp, class _Ref, class _Ptr> bool std::operator<(const std::_Deque_iterator<_Tp, _Ref, _Ptr>&, const std::_Deque_iterator<_Tp, _Ref, _Ptr>&)
     operator<(const _Deque_iterator<_Tp, _Ref, _Ptr>& __x,
     ^
/usr/include/c++/4.8/bits/stl_deque.h:273:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::_Deque_iterator<_Tp, _Ref, _Ptr>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/deque:64:0,
                 from /usr/include/boost/detail/container_fwd.hpp:91,
                 from /usr/include/boost/functional/hash/extensions.hpp:17,
                 from /usr/include/boost/functional/hash/hash.hpp:529,
                 from /usr/include/boost/functional/hash.hpp:6,
                 from /usr/include/boost/unordered/unordered_set.hpp:20,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_deque.h:281:5: note: template<class _Tp, class _RefL, class _PtrL, class _RefR, class _PtrR> bool std::operator<(const std::_Deque_iterator<_Tp, _Ref, _Ptr>&, const std::_Deque_iterator<_Tp, _RefR, _PtrR>&)
     operator<(const _Deque_iterator<_Tp, _RefL, _PtrL>& __x,
     ^
/usr/include/c++/4.8/bits/stl_deque.h:281:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::_Deque_iterator<_Tp, _Ref, _Ptr>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/deque:64:0,
                 from /usr/include/boost/detail/container_fwd.hpp:91,
                 from /usr/include/boost/functional/hash/extensions.hpp:17,
                 from /usr/include/boost/functional/hash/hash.hpp:529,
                 from /usr/include/boost/functional/hash.hpp:6,
                 from /usr/include/boost/unordered/unordered_set.hpp:20,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_deque.h:1975:5: note: template<class _Tp, class _Alloc> bool std::operator<(const std::deque<_Tp, _Alloc>&, const std::deque<_Tp, _Alloc>&)
     operator<(const deque<_Tp, _Alloc>& __x,
     ^
/usr/include/c++/4.8/bits/stl_deque.h:1975:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::deque<_Tp, _Alloc>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/list:63:0,
                 from /usr/include/boost/detail/container_fwd.hpp:92,
                 from /usr/include/boost/functional/hash/extensions.hpp:17,
                 from /usr/include/boost/functional/hash/hash.hpp:529,
                 from /usr/include/boost/functional/hash.hpp:6,
                 from /usr/include/boost/unordered/unordered_set.hpp:20,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_list.h:1631:5: note: template<class _Tp, class _Alloc> bool std::operator<(const std::list<_Tp, _Alloc>&, const std::list<_Tp, _Alloc>&)
     operator<(const list<_Tp, _Alloc>& __x, const list<_Tp, _Alloc>& __y)
     ^
/usr/include/c++/4.8/bits/stl_list.h:1631:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::list<_Tp, _Alloc>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/vector:64:0,
                 from /usr/include/boost/detail/container_fwd.hpp:93,
                 from /usr/include/boost/functional/hash/extensions.hpp:17,
                 from /usr/include/boost/functional/hash/hash.hpp:529,
                 from /usr/include/boost/functional/hash.hpp:6,
                 from /usr/include/boost/unordered/unordered_set.hpp:20,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_vector.h:1421:5: note: template<class _Tp, class _Alloc> bool std::operator<(const std::vector<_Tp, _Alloc>&, const std::vector<_Tp, _Alloc>&)
     operator<(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
     ^
/usr/include/c++/4.8/bits/stl_vector.h:1421:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::vector<_Tp, _Alloc>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/map:60:0,
                 from /usr/include/boost/detail/container_fwd.hpp:94,
                 from /usr/include/boost/functional/hash/extensions.hpp:17,
                 from /usr/include/boost/functional/hash/hash.hpp:529,
                 from /usr/include/boost/functional/hash.hpp:6,
                 from /usr/include/boost/unordered/unordered_set.hpp:20,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_tree.h:917:5: note: template<class _Key, class _Val, class _KeyOfValue, class _Compare, class _Alloc> bool std::operator<(const std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>&, const std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>&)
     operator<(const _Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>& __x,
     ^
/usr/include/c++/4.8/bits/stl_tree.h:917:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/map:61:0,
                 from /usr/include/boost/detail/container_fwd.hpp:94,
                 from /usr/include/boost/functional/hash/extensions.hpp:17,
                 from /usr/include/boost/functional/hash/hash.hpp:529,
                 from /usr/include/boost/functional/hash.hpp:6,
                 from /usr/include/boost/unordered/unordered_set.hpp:20,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_map.h:979:5: note: template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator<(const std::map<_Key, _Tp, _Compare, _Alloc>&, const std::map<_Key, _Tp, _Compare, _Alloc>&)
     operator<(const map<_Key, _Tp, _Compare, _Alloc>& __x,
     ^
/usr/include/c++/4.8/bits/stl_map.h:979:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::map<_Key, _Tp, _Compare, _Alloc>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/map:62:0,
                 from /usr/include/boost/detail/container_fwd.hpp:94,
                 from /usr/include/boost/functional/hash/extensions.hpp:17,
                 from /usr/include/boost/functional/hash/hash.hpp:529,
                 from /usr/include/boost/functional/hash.hpp:6,
                 from /usr/include/boost/unordered/unordered_set.hpp:20,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_multimap.h:881:5: note: template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator<(const std::multimap<_Key, _Tp, _Compare, _Alloc>&, const std::multimap<_Key, _Tp, _Compare, _Alloc>&)
     operator<(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
     ^
/usr/include/c++/4.8/bits/stl_multimap.h:881:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::multimap<_Key, _Tp, _Compare, _Alloc>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/set:61:0,
                 from /usr/include/boost/detail/container_fwd.hpp:95,
                 from /usr/include/boost/functional/hash/extensions.hpp:17,
                 from /usr/include/boost/functional/hash/hash.hpp:529,
                 from /usr/include/boost/functional/hash.hpp:6,
                 from /usr/include/boost/unordered/unordered_set.hpp:20,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_set.h:771:5: note: template<class _Key, class _Compare, class _Alloc> bool std::operator<(const std::set<_Key, _Compare, _Alloc>&, const std::set<_Key, _Compare, _Alloc>&)
     operator<(const set<_Key, _Compare, _Alloc>& __x,
     ^
/usr/include/c++/4.8/bits/stl_set.h:771:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::set<_Key, _Compare, _Alloc>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/set:62:0,
                 from /usr/include/boost/detail/container_fwd.hpp:95,
                 from /usr/include/boost/functional/hash/extensions.hpp:17,
                 from /usr/include/boost/functional/hash/hash.hpp:529,
                 from /usr/include/boost/functional/hash.hpp:6,
                 from /usr/include/boost/unordered/unordered_set.hpp:20,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_multiset.h:756:5: note: template<class _Key, class _Compare, class _Alloc> bool std::operator<(const std::multiset<_Key, _Compare, _Alloc>&, const std::multiset<_Key, _Compare, _Alloc>&)
     operator<(const multiset<_Key, _Compare, _Alloc>& __x,
     ^
/usr/include/c++/4.8/bits/stl_multiset.h:756:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::multiset<_Key, _Compare, _Alloc>’
       { return __x < __y; }
                    ^
In file included from /usr/include/c++/4.8/stack:61:0,
                 from /usr/include/boost/filesystem/operations.hpp:42,
                 from /usr/include/boost/filesystem.hpp:17,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:33:
/usr/include/c++/4.8/bits/stl_stack.h:261:5: note: template<class _Tp, class _Seq> bool std::operator<(const std::stack<_Tp, _Seq>&, const std::stack<_Tp, _Seq>&)
     operator<(const stack<_Tp, _Seq>& __x, const stack<_Tp, _Seq>& __y)
     ^
/usr/include/c++/4.8/bits/stl_stack.h:261:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/4.8/functional:49:0,
                 from /usr/include/boost/unordered/unordered_set_fwd.hpp:15,
                 from /usr/include/boost/unordered/unordered_set.hpp:16,
                 from /usr/include/boost/unordered_set.hpp:16,
                 from /usr/include/boost/tr1/unordered_set.hpp:21,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/include/rospack/rospack.h:108,
                 from /home/n130s/link/ROS/indigo_trusty/cws_rosdt/src/ros/rospack/src/rospack.cpp:28:
/usr/include/c++/4.8/bits/stl_function.h:235:20: note:   ‘const rospack::Stackage’ is not derived from ‘const std::stack<_Tp, _Seq>’
       { return __x < __y; }
                    ^
make[2]: *** [CMakeFiles/rospack.dir/src/rospack.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/rospack.dir/all] Error 2
make: *** [all] Error 2
cd /home/n130s/link/ROS/indigo_trusty/cws_rosdt/build/rospack; catkin build --get-env rospack | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
.........................................................................................................
Failed     << rospack:make           [ Exited with code 2 ]
Failed    <<< rospack                [ 3.7 seconds ]
[build] Summary: 0 of 1 packages succeeded.
[build]   Ignored:   98 packages were skipped or are blacklisted.
[build]   Warnings:  None.
[build]   Abandoned: None.
[build]   Failed:    1 packages failed.
[build] Runtime: 4.2 seconds total.
```
